### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/jzkit/attic/jzkit_model2_assembly/pom.xml
+++ b/jzkit/attic/jzkit_model2_assembly/pom.xml
@@ -82,7 +82,7 @@
 
     <dependency> <groupId>log4j</groupId> <artifactId>log4j</artifactId> <version>1.2.13</version> </dependency>
     <dependency> <groupId>commons-logging</groupId> <artifactId>commons-logging</artifactId> <version>1.1.1</version> </dependency>
-    <dependency> <groupId>commons-collections</groupId> <artifactId>commons-collections</artifactId> <version>3.2.1</version> </dependency>
+    <dependency> <groupId>commons-collections</groupId> <artifactId>commons-collections</artifactId> <version>3.2.2</version> </dependency>
 
     <dependency> <groupId>org.apache.derby</groupId> <artifactId>derby</artifactId> <version>10.3.1.4</version> </dependency>
     <dependency> <groupId>org.apache.derby</groupId> <artifactId>derbyclient</artifactId> <version>10.3.1.4</version> </dependency>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That is the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
